### PR TITLE
bugfix: called _mouse_click in test__mouse_move

### DIFF
--- a/test/test_ThetanArenaEnv.py
+++ b/test/test_ThetanArenaEnv.py
@@ -24,6 +24,6 @@ class ThetanArenaEnvTestCase(unittest.TestCase):
 		coordinate of game window)
 		"""
 		expected = np.asarray(pyautogui.size()) * np.asarray(self.args);
-		self.env._mouse_click(*self.args);
+		self.env._mouse_move(self.args);
 		result = np.asarray(pyautogui.position());
 		self.assertTrue(np.abs(expected - result) < 2);


### PR DESCRIPTION
The test case of `_mouse_move` was wrong. It called `_mouse_click` in test. #32 