### PR TITLE
Bugfix

### DIFF
--- a/MineShaft/BaseEnv.py
+++ b/MineShaft/BaseEnv.py
@@ -80,8 +80,8 @@ class BaseEnv(gym.Env):
         # Define action and observation space
         # They must be gym.spaces objects
         if io_mode == IO_MODE.FULL_CONTROL:
-            # 101 keyboard + mouse (move + click + scroll)
-            ACTION_SHAPE = (2, 101 + (2 + 2 + 1))
+            # press & release channels; 104 keyboard + mouse (move + click + scroll)
+            ACTION_SHAPE = (2, 104 + (2 + 2 + 1))
             # screen height
             HEIGHT = 512
             # screen width

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ to prevent reject of pull request ( 🚧 `400 Bad Request`) and make both of us 
 
 ## Functional requirements
 ### Initialize environment
-- [ ] Find and start Thetan Arena in Windows. Throw an error if Thetan Arena cannot be found installed in the system.
+- [x] Find and start Thetan Arena in Windows. Throw an error if Thetan Arena cannot be found installed in the system.
 - [ ] Find and capture part of the screen only the game window of Thetan Arena.
 ### Input action
 - [ ] Input given key as keyboard press or keydown or keyup event.
@@ -49,7 +49,7 @@ to prevent reject of pull request ( 🚧 `400 Bad Request`) and make both of us 
 - [ ] Capture part of the screen only the game window of Thetan Arena.
 - [ ] The frame-rate of screen capture must be more than 30 frames-per-second.
 ### Terminate environment
-- [ ] Quit on-going game and exit the program Thetan Arena. And then destroy the MineShaft class instance itself.
+- [x] Quit on-going game and exit the program Thetan Arena. And then destroy the MineShaft class instance itself.
 
 ## Supported GameFis
 - Thetan Arena

--- a/test/test_ThetanArenaEnv.py
+++ b/test/test_ThetanArenaEnv.py
@@ -75,39 +75,36 @@ class ThetanArenaEnvTestCase(unittest.TestCase):
 			sequence).
 			```
 			[
-				'!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+',
-				',', '-', '.', '/', '0', '1', '2', '3', '4', '5', '6',
-				'7', '8', '9', ':', ';', '<', '=', '>', '?', '@', '[',
-				'\\', ']', '^', '_', '`', 'a', 'b', 'c', 'd', 'e','f',
-				'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q',
-				'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '{', '|',
-				'}', '~', 'altleft', 'altright', 'backspace', 'capslock',
-				'ctrlleft', 'ctrlright', 'delete', 'divide', 'down', 'end',
-				'enter', 'esc', 'escape', 'f1', 'f10', 'f11', 'f12', 'f13',
-				'f14', 'f15', 'f16', 'f17', 'f18', 'f19', 'f2', 'f20', 'f21',
-				'f22', 'f23', 'f24', 'f3', 'f4', 'f5', 'f6', 'f7', 'f8', 'f9',
-				'insert', 'left', 'multiply', 'num0', 'num1', 'num2', 'num3',
-				'num4', 'num5', 'num6', 'num7', 'num8', 'num9', 'numlock',
-				'pagedown', 'pageup', 'pause', 'right', 'shiftleft',
-				'shiftright', 'space', 'stop', 'subtract', 'tab',
-				'up', 'command', 'optionleft', 'optionright'
+				"'", ',', '-', '.', '/', '0', '1', '2', '3', '4', '5',
+				'6', '7', '8', '9', ';', '=', '[', '\\', ']', '`', 'a',
+				'b', 'c', 'd', 'e','f', 'g', 'h', 'i', 'j', 'k', 'l',
+				'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w',
+				'x', 'y', 'z', 'altleft', 'altright', 'backspace',
+				'capslock', 'ctrlleft', 'ctrlright', 'delete', 'down',
+				'end', 'enter', 'esc', 'f1', 'f10', 'f11', 'f12', 'f13',
+				'f14', 'f15', 'f16', 'f17', 'f18', 'f19', 'f2', 'f20',
+				'f21', 'f22', 'f23', 'f24', 'f3', 'f4', 'f5', 'f6', 'f7',
+				'f8', 'f9', 'insert', 'left', 'num0', 'num1', 'num2',
+				'num3', 'num4', 'num5', 'num6', 'num7', 'num8', 'num9',
+				'numlock', 'pagedown', 'pageup', 'right', 'shiftleft',
+				'shiftright', 'space', 'tab', 'up', 'home'
 			]
 			```
-			The value of force will be in range `0` to `1` and it is considered
-			to be pressed down only if the value is larger than `0.5`.
+			The value of force will be in range `-1` to `1` and it is considered
+			to be pressed down only if the value is larger than `0`.
 		"""
-		action_a = np.zeros((133));
-		action_a[38] = 1;
+		action_a = np.zeros((104));
+		action_a[21] = 1;
 		# press "a"
 		self.env._keyboard_press(action_a);
 		assert keyboard.is_pressed("a");
-		self.env._keyboard_release( 1 - action_a);
+		self.env._keyboard_release(action_a);
 		assert not keyboard.is_pressed("a");
-		action_ctrl_a = np.zeros((133));
-		action_ctrl_a[38] = 1;
-		action_ctrl_a[72] = 1;
+		action_ctrl_a = np.zeros((104));
+		action_ctrl_a[21] = 1;
+		action_ctrl_a[51] = 1;
 		# press Ctrl+a
 		self.env._keyboard_press(action_ctrl_a);
 		assert keyboard.is_pressed('ctrl+a');
-		self.env._keyboard_release( 1 - action_ctrl_a);
+		self.env._keyboard_release(action_ctrl_a);
 		assert not keyboard.is_pressed('ctrl+a');


### PR DESCRIPTION
fatal test case for keyboard does not match with BaseEnv #37 

Now aligned to:
```
[
	"'", ',', '-', '.', '/', '0', '1', '2', '3', '4', '5',
	'6', '7', '8', '9', ';', '=', '[', '\\', ']', '`', 'a',
	'b', 'c', 'd', 'e','f', 'g', 'h', 'i', 'j', 'k', 'l',
	'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w',
	'x', 'y', 'z', 'altleft', 'altright', 'backspace',
	'capslock', 'ctrlleft', 'ctrlright', 'delete', 'down',
	'end', 'enter', 'esc', 'f1', 'f10', 'f11', 'f12', 'f13',
	'f14', 'f15', 'f16', 'f17', 'f18', 'f19', 'f2', 'f20',
	'f21', 'f22', 'f23', 'f24', 'f3', 'f4', 'f5', 'f6', 'f7',
	'f8', 'f9', 'insert', 'left', 'num0', 'num1', 'num2',
	'num3', 'num4', 'num5', 'num6', 'num7', 'num8', 'num9',
	'numlock', 'pagedown', 'pageup', 'right', 'shiftleft',
	'shiftright', 'space', 'tab', 'up', 'home'
]
```