### PR TITLE
Bugfix/integration baseline3

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,22 +1,32 @@
+import time
+
 from stable_baselines3 import PPO
 
 from MineShaft import ThetanArenaEnv
 
 def main():
 	env = ThetanArenaEnv()
-	env.enter_match()
-	# env.enter_match(random_character=True)
 	model = PPO("MlpPolicy", env, verbose=1)
 	model.learn(total_timesteps=10_000)
 
 	info = {'waiting': True}
 	action = env.action_space.sample()
-	for _ in range(1000):
+	action = action * 0
+	i = 0
+	while i < 10_000:
+		start_time = time.time()
 		if not info['waiting']:
 			action, _states = model.predict(observation, deterministic=True)
+		else:
+			i -= 1
 		observation, reward, done, info = env.step(action)
 		if done:
 			observation = env.reset()
+		if time.time() - start_time < 0.9:
+			try:
+				time.sleep(0.1 - time.time() - start_time)
+			except:
+				pass
 
 	env.close()
 


### PR DESCRIPTION
```
Using cpu device
Wrapping the env with a `Monitor` wrapper
Wrapping the env in a DummyVecEnv.
Wrapping the env in a VecTransposeImage.
Traceback (most recent call last):
  File "test.py", line 38, in <module>
    main()
  File "test.py", line 13, in main
    model = PPO("MlpPolicy", env, verbose=1)
...
    self.action_dist = make_proba_distribution(action_space, use_sde=use_sde, dist_kwargs=dist_kwargs)
  File "C:\Users\user\AppData\Local\Continuum\anaconda3\envs\thg\lib\site-packages\stable_baselines3\common\distributions.py",
ine 661, in make_proba_distribution
    assert len(action_space.shape) == 1, "Error: the action space must be a vector"
AssertionError: Error: the action space must be a vector****
```